### PR TITLE
Fixed 'warning 208' thx to Southclaw

### DIFF
--- a/sqlitei.inc
+++ b/sqlitei.inc
@@ -740,6 +740,7 @@ stock db_set_struct_info(DB:db, {_, e_SQLITE3}:iOffset, iValue) {
 	#emit SREF.S.pri  iAddress
 }
 
+forward bool:db_set_row_index(DBResult:dbrResult, iRow);
 stock bool:db_set_row_index(DBResult:dbrResult, iRow) {
 	if (dbrResult == DB::INVALID_RESULT) {
 		DB::Notice("(db_set_row_index) Invalid result given.");
@@ -904,6 +905,7 @@ stock db_is_result_freed(DBResult:dbrResult) {
 	return (iData == 0xFFFFFFFF);
 }
 
+forward bool:db_free_result_hook(DBResult:dbrResult);
 stock bool:db_free_result_hook(DBResult:dbrResult) {
 	if (dbrResult == DB::INVALID_RESULT) {
 		DB::Notice("(db_free_result_hook) Invalid result given.");
@@ -1041,6 +1043,7 @@ stock db_set_asynchronous(DB:db, bool:bSet = true) {
 	db_set_synchronous(DB:db, bSet ? DB::SYNCHRONOUS_OFF : DB::SYNCHRONOUS_FULL);
 }
 
+forward bool:db_set_synchronous(DB:db, DB::e_SYNCHRONOUS_MODE:iValue);
 stock bool:db_set_synchronous(DB:db, DB::e_SYNCHRONOUS_MODE:iValue) {
 	if (0 <= _:iValue <= 2) {
 		format(gs_szBuffer, sizeof(gs_szBuffer), "PRAGMA synchronous = %d", _:iValue);


### PR DESCRIPTION
Fixed 'warning 208: function with tag result used before definition, forcing reparse' for these functions:
-bool:db_set_row_index
-bool:db_free_result_hook
-bool:db_set_synchronous

@Southclaw
Not entirely sure why this happens, but I know one fix for it is to put a "forward" line for the affected functions. However, I'm not sure if that has any repercussions on performance or memory use.
